### PR TITLE
Add the poetry-core host requirement and bump to v24.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   host:
     - python >=3.6,<4.0
     - pip
+    - poetry-core
   run:
     - python >=3.6,<4.0
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycountry" %}
-{% set version = "22.3.5" %}
+{% set version = "24.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b2163a246c585894d808f18783e19137cb70a0c18fb36748dc01fc6f109c1646
+  sha256: b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221
 
 build:
   noarch: python


### PR DESCRIPTION
Trying to fix the issue that `pycountry` is not building because `poetry` is not available.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
